### PR TITLE
Add blog mock data and pages

### DIFF
--- a/docs/mock-data.md
+++ b/docs/mock-data.md
@@ -1,0 +1,14 @@
+# Mock Data
+
+This project uses a simple array of posts defined in `src/shared/constants/posts.ts`.
+Each post contains the following fields:
+
+- `id`: unique identifier
+- `title`: post title
+- `summary`: short description
+- `createdAt`: creation date
+- `updatedAt`: last update date
+- `tags`: array of tag strings
+- `content`: full text shown on the detail page
+
+The mock data is used on the Home, Posts and Tags pages.

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,12 +2,14 @@ import {
   RouterProvider,
   Route,
   RootRoute,
-  Outlet,
   createRouter,
 } from '@tanstack/react-router'
 import Layout from '../shared/components/layouts/Layout'
 import Home from '../pages/home'
 import About from '../pages/about'
+import PostsPage from '../pages/posts'
+import PostDetail from '../pages/posts/$postId'
+import TagsPage from '../pages/tags'
 
 const rootRoute = new RootRoute({
   component: Layout,
@@ -25,7 +27,31 @@ const aboutRoute = new Route({
   component: About,
 })
 
-const routeTree = rootRoute.addChildren([homeRoute, aboutRoute])
+const postsRoute = new Route({
+  getParentRoute: () => rootRoute,
+  path: '/posts',
+  component: PostsPage,
+})
+
+const postDetailRoute = new Route({
+  getParentRoute: () => rootRoute,
+  path: '/posts/$postId',
+  component: PostDetail,
+})
+
+const tagsRoute = new Route({
+  getParentRoute: () => rootRoute,
+  path: '/tags',
+  component: TagsPage,
+})
+
+const routeTree = rootRoute.addChildren([
+  homeRoute,
+  aboutRoute,
+  postsRoute,
+  postDetailRoute,
+  tagsRoute,
+])
 export const router = createRouter({ routeTree })
 
 declare module '@tanstack/react-router' {

--- a/src/pages/posts/$postId.tsx
+++ b/src/pages/posts/$postId.tsx
@@ -1,0 +1,14 @@
+import { useParams } from '@tanstack/react-router'
+import { posts } from '../../shared/constants/posts'
+
+export default function PostDetail() {
+  const { postId } = useParams({ from: '/posts/$postId' })
+  const post = posts.find((p) => p.id === postId)
+  if (!post) return <div>Post not found</div>
+  return (
+    <article>
+      <h1>{post.title}</h1>
+      <p>{post.content}</p>
+    </article>
+  )
+}

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -1,13 +1,10 @@
 import PostCard from '../../shared/components/blocks/PostCard'
 import { posts } from '../../shared/constants/posts'
 
-export default function Home() {
-  const latest = [...posts].sort((a, b) =>
-    b.updatedAt.localeCompare(a.updatedAt),
-  ).slice(0, 5)
+export default function PostsPage() {
   return (
     <div>
-      {latest.map((post) => (
+      {posts.map((post) => (
         <PostCard key={post.id} post={post} />
       ))}
     </div>

--- a/src/pages/tags/index.tsx
+++ b/src/pages/tags/index.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react'
+import PostCard from '../../shared/components/blocks/PostCard'
+import { posts } from '../../shared/constants/posts'
+
+export default function TagsPage() {
+  const [selected, setSelected] = useState<string[]>([])
+  const tags = Array.from(new Set(posts.flatMap((p) => p.tags)))
+  const filtered =
+    selected.length === 0
+      ? posts
+      : posts.filter((p) => selected.every((t) => p.tags.includes(t)))
+
+  const toggle = (tag: string) => {
+    setSelected((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag],
+    )
+  }
+
+  return (
+    <div>
+      <div className="mb-4">
+        {tags.map((tag) => (
+          <button
+            key={tag}
+            onClick={() => toggle(tag)}
+            className={`mr-2 ${selected.includes(tag) ? 'font-bold' : ''}`}
+          >
+            {tag} ({posts.filter((p) => p.tags.includes(tag)).length})
+          </button>
+        ))}
+      </div>
+      {filtered.map((post) => (
+        <PostCard key={post.id} post={post} />
+      ))}
+    </div>
+  )
+}

--- a/src/shared/components/blocks/PostCard.test.tsx
+++ b/src/shared/components/blocks/PostCard.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import { vi } from 'vitest'
+import PostCard from './PostCard'
+import type { Post } from '../../types/post'
+import type { ReactNode } from 'react'
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: (props: { children: ReactNode }) => <a>{props.children}</a>,
+}))
+
+describe('PostCard', () => {
+  const post: Post = {
+    id: '1',
+    title: 'Test Post',
+    summary: 'summary',
+    createdAt: '2024-01-01',
+    updatedAt: '2024-01-02',
+    tags: ['tag1'],
+    content: 'content',
+  }
+
+  it('renders post information', () => {
+    render(<PostCard post={post} />)
+    expect(screen.getByText('Test Post')).toBeInTheDocument()
+    expect(screen.getByText('summary')).toBeInTheDocument()
+    expect(screen.getByText(/Created/)).toBeInTheDocument()
+  })
+})

--- a/src/shared/components/blocks/PostCard.tsx
+++ b/src/shared/components/blocks/PostCard.tsx
@@ -1,0 +1,29 @@
+import { Link } from '@tanstack/react-router'
+import type { Post } from '../../types/post'
+
+export interface PostCardProps {
+  post: Post
+}
+
+export default function PostCard({ post }: PostCardProps) {
+  return (
+    <div className="border rounded p-4 mb-4">
+      {post.image && <img src={post.image} alt="" className="mb-2" />}
+      <h2 className="text-xl font-bold">
+        <Link to={`/posts/${post.id}`}>{post.title}</Link>
+      </h2>
+      <p>{post.summary}</p>
+      <div className="text-sm text-gray-500">
+        <span>Created: {post.createdAt}</span> |{' '}
+        <span>Updated: {post.updatedAt}</span>
+      </div>
+      <div>
+        {post.tags.map((tag) => (
+          <span key={tag} className="mr-2 text-blue-600">
+            #{tag}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/shared/components/layouts/Header.test.tsx
+++ b/src/shared/components/layouts/Header.test.tsx
@@ -3,9 +3,10 @@ import { describe, it, expect } from 'vitest'
 import '@testing-library/jest-dom'
 import { Header } from './Header'
 import { vi } from 'vitest'
+import type { ReactNode } from 'react'
 
 vi.mock('@tanstack/react-router', () => ({
-  Link: (props: any) => <a>{props.children}</a>,
+  Link: (props: { children: ReactNode }) => <a>{props.children}</a>,
 }))
 
 describe('Header', () => {

--- a/src/shared/components/layouts/Header.tsx
+++ b/src/shared/components/layouts/Header.tsx
@@ -2,11 +2,40 @@ import { Link } from '@tanstack/react-router'
 
 export function Header() {
   return (
-    <header className="p-4 shadow">
-      <h1>Blog Codex</h1>
-      <nav>
-        <Link to="/">Home</Link> | <Link to="/about">About</Link>
-      </nav>
+    <header className="p-4 shadow sticky top-0 bg-white z-10">
+      <div className="flex justify-between items-center">
+        <h1>Blog Codex</h1>
+        <nav>
+          <Link to="/" className="mr-2">
+            Home
+          </Link>
+          <Link to="/posts" className="mr-2">
+            Posts
+          </Link>
+          <Link to="/tags" className="mr-2">
+            Tags
+          </Link>
+          <Link to="/about" className="mr-2">
+            About
+          </Link>
+          <a
+            href="https://github.com/example"
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label="GitHub"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 16 16"
+              width="20"
+              height="20"
+              fill="currentColor"
+            >
+              <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.5 7.5 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
+            </svg>
+          </a>
+        </nav>
+      </div>
     </header>
   )
 }

--- a/src/shared/constants/posts.ts
+++ b/src/shared/constants/posts.ts
@@ -1,0 +1,49 @@
+import type { Post } from '../types/post'
+
+export const posts: Post[] = [
+  {
+    id: '1',
+    title: 'First Post',
+    summary: 'This is the first mock post.',
+    createdAt: '2024-01-01',
+    updatedAt: '2024-01-02',
+    tags: ['intro', 'welcome'],
+    content: 'Content of the first post.',
+  },
+  {
+    id: '2',
+    title: 'Second Post',
+    summary: 'This is the second mock post.',
+    createdAt: '2024-02-01',
+    updatedAt: '2024-02-03',
+    tags: ['update'],
+    content: 'Content of the second post.',
+  },
+  {
+    id: '3',
+    title: 'Third Post',
+    summary: 'This is the third mock post.',
+    createdAt: '2024-03-01',
+    updatedAt: '2024-03-02',
+    tags: ['news'],
+    content: 'Content of the third post.',
+  },
+  {
+    id: '4',
+    title: 'Fourth Post',
+    summary: 'This is the fourth mock post.',
+    createdAt: '2024-04-01',
+    updatedAt: '2024-04-02',
+    tags: ['news'],
+    content: 'Content of the fourth post.',
+  },
+  {
+    id: '5',
+    title: 'Fifth Post',
+    summary: 'This is the fifth mock post.',
+    createdAt: '2024-05-01',
+    updatedAt: '2024-05-02',
+    tags: ['update'],
+    content: 'Content of the fifth post.',
+  },
+]

--- a/src/shared/types/post.ts
+++ b/src/shared/types/post.ts
@@ -1,0 +1,10 @@
+export interface Post {
+  id: string
+  title: string
+  summary: string
+  image?: string
+  createdAt: string
+  updatedAt: string
+  tags: string[]
+  content: string
+}


### PR DESCRIPTION
## Summary
- create posts mock data
- add PostCard component with tests
- implement Home, Posts and Tags pages using the mock data
- configure routes and navigation
- document mock data structure

## Testing
- `npm run test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684feef4b410832cb01cfa21647b6ec4