### PR TITLE
Implement post pagination

### DIFF
--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -1,12 +1,32 @@
+import { useState } from 'react'
 import PostCard from '../../shared/components/blocks/PostCard'
 import { posts } from '../../shared/constants/posts'
+import { getPostsByPage, generatePostIndex } from '../../shared/libs/pagination'
+
+const PER_PAGE = 10
+const postIndex = generatePostIndex(posts, PER_PAGE)
 
 export default function PostsPage() {
+  const [page, setPage] = useState(1)
+  const pagedPosts = getPostsByPage(posts, page, PER_PAGE)
+  const totalPages = postIndex.length
+
   return (
     <div>
-      {posts.map((post) => (
+      {pagedPosts.map((post) => (
         <PostCard key={post.id} post={post} />
       ))}
+      <div className="mt-4 flex justify-center space-x-2">
+        <button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1}>
+          Prev
+        </button>
+        <span>
+          {page} / {totalPages || 1}
+        </span>
+        <button onClick={() => setPage((p) => Math.min(totalPages, p + 1))} disabled={page >= totalPages}>
+          Next
+        </button>
+      </div>
     </div>
   )
 }

--- a/src/shared/libs/pagination.test.ts
+++ b/src/shared/libs/pagination.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest'
+import { generatePostIndex, getPostsByPage } from './pagination'
+
+const makePosts = (count: number) => {
+  return Array.from({ length: count }).map((_, i) => ({
+    id: `${i + 1}`,
+    createdAt: `2024-01-${(i + 1).toString().padStart(2, '0')}`,
+  }))
+}
+
+describe('generatePostIndex', () => {
+  it('returns empty array when no posts', () => {
+    expect(generatePostIndex([])).toEqual([])
+  })
+
+  it('handles exactly perPage posts', () => {
+    const posts = makePosts(10)
+    const index = generatePostIndex(posts)
+    expect(index.length).toBe(1)
+    expect(index[0].length).toBe(10)
+  })
+
+  it('handles one more than perPage', () => {
+    const posts = makePosts(11)
+    const index = generatePostIndex(posts)
+    expect(index.length).toBe(2)
+    expect(index[1].length).toBe(1)
+  })
+})
+
+describe('getPostsByPage', () => {
+  it('returns empty when page < 1', () => {
+    const posts = makePosts(5)
+    expect(getPostsByPage(posts, 0)).toEqual([])
+  })
+
+  it('returns first page of sorted posts', () => {
+    const posts = makePosts(3)
+    const result = getPostsByPage(posts, 1, 2)
+    expect(result.map(p => p.id)).toEqual(['3','2'])
+  })
+
+  it('returns remaining posts on last page', () => {
+    const posts = makePosts(5)
+    const result = getPostsByPage(posts, 3, 2)
+    expect(result.map(p => p.id)).toEqual(['1'])
+  })
+})

--- a/src/shared/libs/pagination.ts
+++ b/src/shared/libs/pagination.ts
@@ -1,0 +1,28 @@
+export function generatePostIndex<T extends { id: string }>(
+  posts: T[],
+  perPage = 10,
+): string[][] {
+  const sorted = [...posts].sort(
+    (a, b) =>
+      new Date(b.createdAt as unknown as string).getTime() -
+      new Date(a.createdAt as unknown as string).getTime(),
+  ) as (T & { createdAt: string })[]
+  const pages: string[][] = []
+  for (let i = 0; i < sorted.length; i += perPage) {
+    pages.push(sorted.slice(i, i + perPage).map((p) => p.id))
+  }
+  return pages
+}
+
+export function getPostsByPage<T extends { createdAt: string }>(
+  posts: T[],
+  page: number,
+  perPage = 10,
+): T[] {
+  if (page < 1) return []
+  const sorted = [...posts].sort(
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  )
+  const start = (page - 1) * perPage
+  return sorted.slice(start, start + perPage)
+}


### PR DESCRIPTION
## Summary
- paginate posts and sort by newest
- add pagination helper functions
- cover pagination boundary cases with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ffa213f40832c8392823f55728fac