### PR TITLE
Add theme switch with shadcn-style components

### DIFF
--- a/docs/theme.md
+++ b/docs/theme.md
@@ -1,0 +1,5 @@
+# Theme Management
+
+The application supports light and dark themes. A `ThemeProvider` component stores the current theme in `localStorage` and toggles a class on the `documentElement` to switch styles. The theme defaults to the user's system preference.
+
+The header includes a `ThemeSwitch` component implemented with a custom `Switch` element from the `ui` library. Clicking the switch toggles between light and dark modes.

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import PostCard from '../../shared/components/blocks/PostCard'
+import { Button } from '../../shared/components/ui/button'
 import { posts } from '../../shared/constants/posts'
 import { getPostsByPage, generatePostIndex } from '../../shared/libs/pagination'
 
@@ -17,15 +18,15 @@ export default function PostsPage() {
         <PostCard key={post.id} post={post} />
       ))}
       <div className="mt-4 flex justify-center space-x-2">
-        <button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1}>
+        <Button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1}>
           Prev
-        </button>
+        </Button>
         <span>
           {page} / {totalPages || 1}
         </span>
-        <button onClick={() => setPage((p) => Math.min(totalPages, p + 1))} disabled={page >= totalPages}>
+        <Button onClick={() => setPage((p) => Math.min(totalPages, p + 1))} disabled={page >= totalPages}>
           Next
-        </button>
+        </Button>
       </div>
     </div>
   )

--- a/src/pages/tags/index.tsx
+++ b/src/pages/tags/index.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import PostCard from '../../shared/components/blocks/PostCard'
+import { Button } from '../../shared/components/ui/button'
 import { posts } from '../../shared/constants/posts'
 
 export default function TagsPage() {
@@ -20,13 +21,13 @@ export default function TagsPage() {
     <div>
       <div className="mb-4">
         {tags.map((tag) => (
-          <button
+          <Button
             key={tag}
             onClick={() => toggle(tag)}
             className={`mr-2 ${selected.includes(tag) ? 'font-bold' : ''}`}
           >
             {tag} ({posts.filter((p) => p.tags.includes(tag)).length})
-          </button>
+          </Button>
         ))}
       </div>
       {filtered.map((post) => (

--- a/src/shared/components/blocks/PostCard.tsx
+++ b/src/shared/components/blocks/PostCard.tsx
@@ -1,5 +1,6 @@
 import { Link } from '@tanstack/react-router'
 import type { Post } from '../../types/post'
+import { Card } from '../ui/card'
 
 export interface PostCardProps {
   post: Post
@@ -7,7 +8,7 @@ export interface PostCardProps {
 
 export default function PostCard({ post }: PostCardProps) {
   return (
-    <div className="border rounded p-4 mb-4">
+    <Card className="mb-4">
       {post.image && <img src={post.image} alt="" className="mb-2" />}
       <h2 className="text-xl font-bold">
         <Link to={`/posts/${post.id}`}>{post.title}</Link>
@@ -24,6 +25,6 @@ export default function PostCard({ post }: PostCardProps) {
           </span>
         ))}
       </div>
-    </div>
+    </Card>
   )
 }

--- a/src/shared/components/blocks/ThemeSwitch.tsx
+++ b/src/shared/components/blocks/ThemeSwitch.tsx
@@ -1,0 +1,9 @@
+import { Switch } from '../ui/switch'
+import { useTheme } from '../containers/theme-provider'
+
+export default function ThemeSwitch() {
+  const { theme, toggle } = useTheme()
+  return (
+    <Switch checked={theme === 'dark'} onCheckedChange={toggle} aria-label="Toggle theme" />
+  )
+}

--- a/src/shared/components/containers/theme-provider.tsx
+++ b/src/shared/components/containers/theme-provider.tsx
@@ -1,0 +1,36 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
+
+type Theme = 'light' | 'dark'
+interface ThemeContextValue {
+  theme: Theme
+  toggle: () => void
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined)
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    if (typeof window === 'undefined') return 'light'
+    const stored = localStorage.getItem('theme') as Theme | null
+    if (stored) return stored
+    return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  })
+
+  useEffect(() => {
+    document.documentElement.classList.remove(theme === 'dark' ? 'light' : 'dark')
+    document.documentElement.classList.add(theme)
+    localStorage.setItem('theme', theme)
+  }, [theme])
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggle: () => setTheme(t => (t === 'light' ? 'dark' : 'light')) }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider')
+  return ctx
+}

--- a/src/shared/components/layouts/Header.test.tsx
+++ b/src/shared/components/layouts/Header.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { describe, it, expect } from 'vitest'
 import '@testing-library/jest-dom'
 import { Header } from './Header'
+import { ThemeProvider } from '../containers/theme-provider'
 import { vi } from 'vitest'
 import type { ReactNode } from 'react'
 
@@ -11,8 +12,13 @@ vi.mock('@tanstack/react-router', () => ({
 
 describe('Header', () => {
   it('shows navigation links', () => {
-    render(<Header />)
+    render(
+      <ThemeProvider>
+        <Header />
+      </ThemeProvider>,
+    )
     expect(screen.getByText('Home')).toBeInTheDocument()
     expect(screen.getByText('About')).toBeInTheDocument()
+    expect(screen.getByRole('switch')).toBeInTheDocument()
   })
 })

--- a/src/shared/components/layouts/Header.tsx
+++ b/src/shared/components/layouts/Header.tsx
@@ -1,11 +1,12 @@
 import { Link } from '@tanstack/react-router'
+import ThemeSwitch from '../blocks/ThemeSwitch'
 
 export function Header() {
   return (
     <header className="p-4 shadow sticky top-0 bg-white z-10">
       <div className="flex justify-between items-center">
         <h1>Blog Codex</h1>
-        <nav>
+        <nav className="flex items-center space-x-2">
           <Link to="/" className="mr-2">
             Home
           </Link>
@@ -34,6 +35,7 @@ export function Header() {
               <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.5 7.5 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z" />
             </svg>
           </a>
+          <ThemeSwitch />
         </nav>
       </div>
     </header>

--- a/src/shared/components/layouts/Layout.tsx
+++ b/src/shared/components/layouts/Layout.tsx
@@ -1,15 +1,18 @@
 import { Outlet } from '@tanstack/react-router'
 import { Header } from './Header'
 import { Footer } from './Footer'
+import { ThemeProvider } from '../containers/theme-provider'
 
 export default function Layout() {
   return (
-    <div className="min-h-screen flex flex-col">
-      <Header />
-      <main className="flex-1 p-4">
-        <Outlet />
-      </main>
-      <Footer />
-    </div>
+    <ThemeProvider>
+      <div className="min-h-screen flex flex-col">
+        <Header />
+        <main className="flex-1 p-4">
+          <Outlet />
+        </main>
+        <Footer />
+      </div>
+    </ThemeProvider>
   )
 }

--- a/src/shared/components/ui/button.tsx
+++ b/src/shared/components/ui/button.tsx
@@ -1,0 +1,14 @@
+import type { ButtonHTMLAttributes } from 'react'
+import { cn } from '../../libs/utils'
+
+export function Button({ className, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      className={cn(
+        'inline-flex items-center justify-center rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-700 disabled:opacity-50',
+        className,
+      )}
+      {...props}
+    />
+  )
+}

--- a/src/shared/components/ui/card.tsx
+++ b/src/shared/components/ui/card.tsx
@@ -1,0 +1,11 @@
+import type { HTMLAttributes } from 'react'
+import { cn } from '../../libs/utils'
+
+export function Card({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('rounded-lg border bg-white p-4 shadow-sm dark:bg-gray-800', className)}
+      {...props}
+    />
+  )
+}

--- a/src/shared/components/ui/switch.tsx
+++ b/src/shared/components/ui/switch.tsx
@@ -1,0 +1,30 @@
+import type { HTMLAttributes } from 'react'
+import { cn } from '../../libs/utils'
+
+interface SwitchProps extends HTMLAttributes<HTMLButtonElement> {
+  checked: boolean
+  onCheckedChange: (checked: boolean) => void
+}
+
+export function Switch({ checked, onCheckedChange, className, ...props }: SwitchProps) {
+  return (
+    <button
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onCheckedChange(!checked)}
+      className={cn(
+        'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
+        checked ? 'bg-blue-600' : 'bg-gray-200',
+        className,
+      )}
+      {...props}
+    >
+      <span
+        className={cn(
+          'inline-block h-4 w-4 transform rounded-full bg-white transition',
+          checked ? 'translate-x-6' : 'translate-x-1',
+        )}
+      />
+    </button>
+  )
+}

--- a/src/shared/libs/utils.ts
+++ b/src/shared/libs/utils.ts
@@ -1,0 +1,3 @@
+export function cn(...classes: Array<string | false | null | undefined>) {
+  return classes.filter(Boolean).join(' ')
+}


### PR DESCRIPTION
## Summary
- create basic shadcn-style `Button`, `Card`, and `Switch`
- wrap layout with `ThemeProvider` and add `ThemeSwitch` to header
- switch pagination and tag buttons to new Button component
- refactor PostCard to use Card
- document theme management

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685015a73b48832c8163e0b5772a2a5b